### PR TITLE
Fix plot.summary.augsynth - add group=1 to aes

### DIFF
--- a/R/augsynth.R
+++ b/R/augsynth.R
@@ -377,7 +377,7 @@ plot.summary.augsynth <- function(x, ...) {
     }
     
     p <- summ$att %>%
-        ggplot2::ggplot(ggplot2::aes(x=Time, y=Estimate))
+        ggplot2::ggplot(ggplot2::aes(x=Time, y=Estimate, group=1))
     if(se) {
         p <- p + ggplot2::geom_ribbon(ggplot2::aes(ymin=Estimate-2*Std.Error,
                         ymax=Estimate+2*Std.Error),


### PR DESCRIPTION
I was getting an error from when trying to plot the results of the model. I think that the ggplot2 aesthetic is missing the group for geom_line to work.

I hope this helps.