### PR TITLE
Fix Reference to Uncreated Object in `multisynth` Vignette

### DIFF
--- a/vignettes/multisynth-vignette.Rmd
+++ b/vignettes/multisynth-vignette.Rmd
@@ -88,7 +88,7 @@ We can then report the level of global and individual balance as well as estimat
 ppool_syn_summ
 ```
 
-`nopool_syn_summ$att` is a dataframe that contains all of the point estimates, standard errors, and lower/upper confidence limits. `Time = NA` denotes the effect averaged across the post treatment periods.
+`ppool_syn_summ$att` is a dataframe that contains all of the point estimates, standard errors, and lower/upper confidence limits. `Time = NA` denotes the effect averaged across the post treatment periods.
 
 ```{r echo = F}
 ppool_syn_summ$att %>%


### PR DESCRIPTION
While going through the vignette for the `multisynth` function, I identified an inconsistency. The document references an object `nopool_syn_summ`, which was not previously created in the provided code. Based on the context, I think the intended reference should be to `ppool_syn_summ`.

This PR addresses this issue by updating the reference to the correct object.

Please review and let me know if any further adjustments are needed.