### PR TITLE
Fix jackknife_se_multi for iterations with truncated matrix length

### DIFF
--- a/R/inference.R
+++ b/R/inference.R
@@ -981,6 +981,13 @@ jackknife_se_multi <- function(multisynth, relative=NULL, alpha = 0.05, att_weig
                        function(i) {
                            msyn_i <- drop_unit_i_multi(multisynth, i)
                            pred <- predict(msyn_i[[1]], relative=relative, att=T, att_weight = att_weight)
+                           if(nrow(pred) < outddim) {
+                               pred <- rbind(
+                                   pred[1:(nrow(pred)-1), ],
+                                   matrix(NA, nrow=outddim-nrow(pred), ncol=ncol(pred)),
+                                   pred[nrow(pred), ]
+                               )
+                           }
                            if(length(msyn_i[[2]]) != 0) {
                                out <- matrix(NA, nrow=nrow(pred), ncol=(J+1))
                                out[,-(msyn_i[[2]]+1)] <- pred


### PR DESCRIPTION
This is a small fix for a bug I encountered when attempting to use jackknife standard errors with a `multisynth` object.

**Issue**: When an earliest-treated unit is dropped in a jackknife iteration, the maximum number of post-treatment periods decreases. This can reduce the number of event-relative time periods for which `predict()` estimates effects, producing an output matrix with fewer rows than the primary result matrix. Within `jackknife_se_multi()`, `vapply()` throws an error because the output matrix dimensions for these iterations do not match the specification.

**Fix**: I added a block that pads the iteration result matrix if it has fewer rows than the primary result matrix.

Thank you for your work on this great package!