### PR TITLE
Fix `progfunc = "GSYN"` under gsynth >= 1.3.0: numeric time index (#107) and fect-era return schema

### DIFF
--- a/R/outcome_models.R
+++ b/R/outcome_models.R
@@ -195,9 +195,10 @@ fit_prog_gsynth <- function(X, y, trt, r=0, r.end=5, force=3, CV=1, ...) {
     long_df_y = gather(df_y, time, obs, -c(unit,trt))
     long_df = rbind(long_df_x, long_df_y)
 
-    transform(long_df, time = as.numeric(time))
-    transform(long_df, unit = as.numeric(unit))
-    gsyn <- gsynth::gsynth(data = long_df, Y = "obs", D = "trt", 
+    ## time comes from gathered column names as character (#107); recode to
+    ## consecutive integers since the names need not be numeric strings
+    long_df$time <- match(long_df$time, unique(long_df$time))
+    gsyn <- gsynth::gsynth(data = long_df, Y = "obs", D = "trt",
                            index = c("unit", "time"), force = force, CV = CV, r = r)
 
     t0 <- dim(X)[2]

--- a/R/outcome_models.R
+++ b/R/outcome_models.R
@@ -206,21 +206,43 @@ fit_prog_gsynth <- function(X, y, trt, r=0, r.end=5, force=3, CV=1, ...) {
     n <- dim(X)[1]
     ## get predicted outcomes
     y0hat <- matrix(0, nrow=n, ncol=(t_final-t0))
-    y0hat[trt==0,]  <- t(gsyn$Y.co[(t0+1):t_final,,drop=FALSE] -
-                             gsyn$est.co$residuals[(t0+1):t_final,,drop=FALSE])
+    if(!is.null(gsyn$est.co)) {
+        ## gsynth < 1.3.0
+        y0hat[trt==0,]  <- t(gsyn$Y.co[(t0+1):t_final,,drop=FALSE] -
+                                 gsyn$est.co$residuals[(t0+1):t_final,,drop=FALSE])
 
-    y0hat[trt==1,] <- gsyn$Y.ct[(t0+1):t_final,]
+        y0hat[trt==1,] <- gsyn$Y.ct[(t0+1):t_final,]
 
-    ## add treated prediction for whole pre-period
-    gsyn$est.co$Y.ct <- gsyn$Y.ct
+        params <- gsyn$est.co
+        ## add treated prediction for whole pre-period
+        params$Y.ct <- gsyn$Y.ct
+    } else {
+        ## gsynth >= 1.3.0 (fect): est.co is renamed est and Y.ct holds
+        ## imputed Y(0) for all units, in gsyn$id order
+        unit_cols <- match(df_x$unit, as.character(gsyn$id))
+        if(anyNA(unit_cols)) {
+            stop("Failed to map units onto the columns of gsynth's Y.ct ",
+                 "(no match in gsyn$id for: ",
+                 paste(df_x$unit[is.na(unit_cols)], collapse = ", "), ")")
+        }
+        y0hat[,] <- t(gsyn$Y.ct[(t0+1):t_final, unit_cols, drop=FALSE])
+
+        params <- gsyn$est
+        ## add treated prediction for whole pre-period
+        params$Y.ct <- gsyn$Y.ct[, gsyn$tr, drop=FALSE]
+        if(is.null(params$factor)) {
+            ## 0-column matrix so ncol(params$factor) works downstream
+            params$factor <- matrix(0, nrow=t_final, ncol=0)
+        }
+    }
 
     ## control and treated residuals
-    gsyn$est.co$ctrl_resids <- gsyn$est.co$residuals
-    gsyn$est.co$trt_resids <- colMeans(cbind(X[trt==1,,drop=FALSE],
-                                             y[trt==1,,drop=FALSE])) -
-        rowMeans(gsyn$est.co$Y.ct)
+    params$ctrl_resids <- params$residuals
+    params$trt_resids <- colMeans(cbind(X[trt==1,,drop=FALSE],
+                                        y[trt==1,,drop=FALSE])) -
+        rowMeans(params$Y.ct)
     return(list(y0hat=y0hat,
-                params=gsyn$est.co))
+                params=params))
 }
 
 

--- a/R/outcome_multi.R
+++ b/R/outcome_multi.R
@@ -27,14 +27,42 @@ fit_gsynth_multi <- function(long_df, X, trt, r=0, force=3, CV=1) {
     gsyn <- gsynth::gsynth(data = long_df, Y = labels[4], D = labels[3], index = c(labels[1], labels[2]), force = force, CV = CV, r=r)
     
     y0hat <- matrix(0, nrow=n, ncol=ttot)
-    y0hat[!is.finite(trt),]  <- t(gsyn$Y.co - gsyn$est.co$residuals)
-    
-    y0hat[is.finite(trt),] <- t(gsyn$Y.ct)
-    
-    ## add treated prediction for whole pre-period
-    gsyn$est.co$Y.ct <- gsyn$Y.ct
+    if(!is.null(gsyn$est.co)) {
+        ## gsynth < 1.3.0
+        y0hat[!is.finite(trt),]  <- t(gsyn$Y.co - gsyn$est.co$residuals)
+
+        y0hat[is.finite(trt),] <- t(gsyn$Y.ct)
+
+        params <- gsyn$est.co
+        ## add treated prediction for whole pre-period
+        params$Y.ct <- gsyn$Y.ct
+    } else {
+        ## gsynth >= 1.3.0 (fect): est.co is renamed est and Y.ct holds
+        ## imputed Y(0) for all units, in gsyn$id order
+        if(!is.null(rownames(X))) {
+            unit_cols <- match(rownames(X), as.character(gsyn$id))
+            if(anyNA(unit_cols)) {
+                stop("Failed to map units onto the columns of gsynth's Y.ct ",
+                     "(no match in gsyn$id for: ",
+                     paste(rownames(X)[is.na(unit_cols)], collapse = ", "), ")")
+            }
+            y0hat[,] <- t(gsyn$Y.ct[, unit_cols, drop=FALSE])
+        } else {
+            ## no unit names: fall back to gsynth's control/treated ordering
+            y0hat[!is.finite(trt),] <- t(gsyn$Y.ct[, gsyn$co, drop=FALSE])
+            y0hat[is.finite(trt),]  <- t(gsyn$Y.ct[, gsyn$tr, drop=FALSE])
+        }
+
+        params <- gsyn$est
+        ## add treated prediction for whole pre-period
+        params$Y.ct <- gsyn$Y.ct[, gsyn$tr, drop=FALSE]
+        if(is.null(params$factor)) {
+            ## 0-column matrix so ncol(params$factor) works downstream
+            params$factor <- matrix(0, nrow=ttot, ncol=0)
+        }
+    }
     return(list(y0hat=y0hat,
-                params=gsyn$est.co))
+                params=params))
 }
 
 

--- a/tests/testthat/test_gsyn_regression.R
+++ b/tests/testthat/test_gsyn_regression.R
@@ -1,0 +1,36 @@
+context("GSYN prognostic function on panels with 10+ time periods")
+
+## time ids 1..30 sort differently as strings than as numbers; the basque
+## panel's 4-digit years do not, which is what hid #107
+test_that("progfunc = 'GSYN' runs on a panel with time ids 1..30", {
+    skip_if_not_installed("gsynth")
+    set.seed(42)
+    n_t <- 30
+    units <- paste0("u", 1:6)
+    df <- expand.grid(region = units, period = 1:n_t, stringsAsFactors = FALSE)
+    df$y <- 100 + 5 * sin(df$period / 3) +
+        as.numeric(factor(df$region)) * 10 + rnorm(nrow(df))
+    df$trt <- ifelse(df$region == "u1" & df$period > 25, 1, 0)
+
+    asyn <- augsynth(y ~ trt, region, period, df, t_int = 26,
+                     progfunc = "GSYN", scm = TRUE, fixedeff = TRUE,
+                     CV = 0, r = 0)
+    expect_true(is.finite(asyn$scaled_l2_imbalance))
+    expect_true(all(is.finite(predict(asyn))))
+    expect_equal(summary(asyn, inf_type = "none")$average_att$Estimate,
+                 0.4796335, tolerance = 1e-4)
+})
+
+test_that("multisynth with a gsynth outcome model runs on a panel with time ids 1..30", {
+    skip_if_not_installed("gsynth")
+    set.seed(42)
+    n_t <- 30
+    units <- paste0("u", 1:8)
+    df <- expand.grid(region = units, period = 1:n_t, stringsAsFactors = FALSE)
+    df$y <- 100 + 5 * sin(df$period / 3) +
+        as.numeric(factor(df$region)) * 10 + rnorm(nrow(df))
+    df$trt <- ifelse(df$region %in% c("u1", "u2") & df$period > 25, 1, 0)
+
+    msyn <- multisynth(y ~ trt, region, period, df, n_factors = 2)
+    expect_true(all(is.finite(predict(msyn))))
+})


### PR DESCRIPTION
Fixes #107.

`progfunc = "GSYN"` is broken with the current CRAN gsynth (>= 1.3.0, now a fect wrapper), for two stacked reasons:

1. The `transform()` calls in `fit_prog_gsynth` don't save their result (#107), so gsynth gets a character time index built from the gathered column names. gsynth now sorts the panel on that index, and `"10" < "2"` lexicographically, so an end-of-panel treatment block looks interleaved and the fit dies with a spurious *"Gsynth can't be used when treatments have reversals."* — on any panel whose time ids sort differently as strings than as numbers. Ids `1..T` do; basque's 4-digit years don't, which is why the existing tests never caught it.
2. With that fixed, the fit still fails with `replacement has length zero`: the fect-era return object has no `$Y.co`/`$est.co` (`est.co` is now `$est`; `$Y.ct` holds imputed Y(0) for all units, T × N in `$id` order). The GSYN test in `test_outcome_models.R` fails this way today.

Changes, one commit each:

- `fit_prog_gsynth`: recode `time` to consecutive integers in order of appearance. Plain `as.numeric()` isn't enough — conformal-inference refits pass matrices whose column names aren't numeric strings. The dead `unit` transform is dropped rather than fixed: unit ids are names, `as.numeric()` would NA them.
- `fit_prog_gsynth` / `fit_gsynth_multi`: branch on `is.null(gsyn$est.co)`. Old gsynth keeps the existing path; for new gsynth, params come from `$est` and `y0hat` from `$Y.ct`, mapped by unit name (with an explicit error if a unit doesn't map). For control units, the new `Y.ct` equals the old `Y.co - est.co$residuals` to machine precision, so this reproduces the old computation exactly.
- Regression tests on a panel with time ids 1..30, including a pinned estimate — the basque tests can't catch the index bug.

Verification (R 4.6.1 arm64, gsynth 1.4.0 / fect 2.4.5): the hard-coded basque GSYN expectation in `test_outcome_models.R` (average ATT −0.1444637, written when pre-1.3.0 gsynth still worked) is reproduced to ~1e-8; on current master that test errors. `multisynth` with a gsynth outcome model runs again, and downstream GeoLift `model = "GSYN"` works end-to-end including the conformal refits. I also ran the full testthat suite: the remaining failures are pre-existing (tests calling non-exported helpers, attach-order assumptions, two osqp tolerance misses in `test_multisynth_covariates.R`) and identical on stock master.

No exported API changes; no roxygen changes, so `man/` is untouched. The old-gsynth branch is semantically unchanged, but I couldn't test against an old gsynth install.
